### PR TITLE
Add settings theme toggle and light palette

### DIFF
--- a/app/src/main/java/com/example/appmanagement/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/main/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.ui.setupWithNavController
 import com.example.appmanagement.R
 import com.example.appmanagement.databinding.ActivityMainBinding
 import com.example.appmanagement.util.TaskReminderScheduler
+import com.example.appmanagement.util.ThemeUtils
 import com.google.android.material.navigation.NavigationBarView
 
 private const val REQUEST_POST_NOTIFICATIONS = 1001
@@ -26,6 +27,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        ThemeUtils.applySavedTheme(this)
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 

--- a/app/src/main/java/com/example/appmanagement/ui/menu/SettingFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/SettingFragment.kt
@@ -6,17 +6,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.example.appmanagement.R
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.databinding.FragmentSettingBinding
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import androidx.lifecycle.lifecycleScope
 import com.example.appmanagement.util.AppGlobals
+import com.example.appmanagement.util.ThemeUtils
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class SettingFragment : Fragment() {
 
@@ -75,6 +76,14 @@ class SettingFragment : Fragment() {
 
         // Back
         b.btnBack.setOnClickListener { findNavController().navigateUp() }
+
+        val themeSwitch = b.switchTheme
+        val isDarkModeEnabled = ThemeUtils.isDarkModeSelected(requireContext())
+        themeSwitch.isChecked = isDarkModeEnabled
+        themeSwitch.setOnCheckedChangeListener { _, isChecked ->
+            ThemeUtils.persistDarkMode(requireContext(), isChecked)
+            ThemeUtils.applyTheme(isChecked)
+        }
 
         // Logout -> Onboard (đã có action trong nav_graph)
         b.btnLogout.setOnClickListener {

--- a/app/src/main/java/com/example/appmanagement/util/ThemeUtils.kt
+++ b/app/src/main/java/com/example/appmanagement/util/ThemeUtils.kt
@@ -1,0 +1,48 @@
+package com.example.appmanagement.util
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.appcompat.app.AppCompatDelegate
+
+private const val PREFS_NAME = "app_settings"
+private const val KEY_DARK_MODE_ENABLED = "dark_mode_enabled"
+
+object ThemeUtils {
+
+    fun applySavedTheme(context: Context) {
+        val shouldUseDarkTheme = isDarkModeSelected(context)
+        applyTheme(shouldUseDarkTheme)
+    }
+
+    fun applyTheme(useDarkMode: Boolean) {
+        val desiredMode = if (useDarkMode) {
+            AppCompatDelegate.MODE_NIGHT_YES
+        } else {
+            AppCompatDelegate.MODE_NIGHT_NO
+        }
+        if (AppCompatDelegate.getDefaultNightMode() != desiredMode) {
+            AppCompatDelegate.setDefaultNightMode(desiredMode)
+        }
+    }
+
+    fun persistDarkMode(context: Context, enabled: Boolean) {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(KEY_DARK_MODE_ENABLED, enabled)
+            .apply()
+    }
+
+    fun isDarkModeSelected(context: Context): Boolean {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return if (prefs.contains(KEY_DARK_MODE_ENABLED)) {
+            prefs.getBoolean(KEY_DARK_MODE_ENABLED, false)
+        } else {
+            isSystemInDarkMode(context)
+        }
+    }
+
+    private fun isSystemInDarkMode(context: Context): Boolean {
+        val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return currentNightMode == Configuration.UI_MODE_NIGHT_YES
+    }
+}

--- a/app/src/main/res/drawable/bg_button_social.xml
+++ b/app/src/main/res/drawable/bg_button_social.xml
@@ -7,7 +7,7 @@
     <corners android:radius="16dp"/>
 
 
-    <stroke android:width="1dp" android:color="#40FFFFFF"/>
+    <stroke android:width="1dp" android:color="@color/outline_neutral"/>
 
     <padding android:left="8dp" android:top="8dp" android:right="8dp" android:bottom="8dp"/>
 </shape>

--- a/app/src/main/res/drawable/bg_color.xml
+++ b/app/src/main/res/drawable/bg_color.xml
@@ -3,7 +3,7 @@
 
     <item>
         <shape android:shape="rectangle">
-            <solid android:color="#181A20" />
+            <solid android:color="@color/background_primary" />
         </shape>
     </item>
 

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -38,7 +38,7 @@
         android:text="Blake Gordon"
         android:textSize="24sp"
         android:textStyle="bold"
-        android:textColor="@android:color/white"
+        android:textColor="@color/text_primary_color"
         android:gravity="center"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
@@ -54,7 +54,7 @@
         android:layout_height="wrap_content"
         android:text="blake@email.com"
         android:textSize="12sp"
-        android:textColor="@android:color/white"
+        android:textColor="@color/text_secondary_color"
         android:gravity="center"
         android:layout_marginStart="24dp"
         android:layout_marginEnd="24dp"
@@ -62,6 +62,62 @@
         app:layout_constraintTop_toBottomOf="@id/tvName"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/themeCard"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginEnd="24dp"
+        app:cardBackgroundColor="@color/background_surface"
+        app:cardCornerRadius="24dp"
+        app:cardUseCompatPadding="false"
+        app:strokeColor="@color/outline_neutral"
+        app:strokeWidth="1dp"
+        app:layout_constraintTop_toBottomOf="@id/tvEmail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:id="@+id/tvThemeTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_theme_title"
+                android:textColor="@color/text_primary_color"
+                android:textSize="16sp"
+                android:textStyle="bold" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:layout_marginTop="12dp">
+
+                <TextView
+                    android:id="@+id/tvThemeSubtitle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/settings_theme_subtitle"
+                    android:textColor="@color/text_secondary_color"
+                    android:textSize="14sp" />
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/switchTheme"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:useMaterialThemeColors="true" />
+            </LinearLayout>
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
 
     <!-- Đăng xuất -->
     <com.google.android.material.button.MaterialButton
@@ -71,7 +127,7 @@
         android:text="Log out"
         android:textAllCaps="false"
         android:textSize="15sp"
-        android:textColor="@android:color/white"
+        android:textColor="@color/text_primary_color"
         app:cornerRadius="26dp"
         android:background="@drawable/bg_button_social"
         android:layout_marginStart="24dp"
@@ -79,5 +135,6 @@
         android:layout_marginBottom="24dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/themeCard"
         app:layout_constraintBottom_toBottomOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Cơ bản -->
+    <color name="black">#000000</color>
+    <color name="white">#FFFFFF</color>
+    <color name="white_soft">#F7F9FC</color>
+
+    <!-- Nền ứng dụng -->
+    <color name="bg_dark">#181A20</color>
+    <color name="card_dark">#1F222A</color>
+
+    <color name="background_primary">@color/bg_dark</color>
+    <color name="background_surface">@color/card_dark</color>
+
+    <!-- Text -->
+    <color name="text_white">#FFFFFF</color>
+    <color name="text_gray">#B0B3B8</color>
+    <color name="text_primary_color">#FFFFFF</color>
+    <color name="text_secondary_color">#B0B3B8</color>
+    <color name="text_highlight">#FFD700</color>
+
+    <color name="outline_neutral">#40FFFFFF</color>
+
+    <!-- Tab / Điều hướng -->
+    <color name="tab_inactive">#808080</color>
+    <color name="tab_active">#FFFFFF</color>
+    <color name="tab_blue">#3D7BFF</color>
+
+    <!-- Primary / Secondary -->
+    <color name="primary">#3D7BFF</color>
+    <color name="secondary">#9B6BFF</color>
+
+    <!-- Progress / Accent gradient -->
+    <color name="gradient_start">#6B88FF</color>
+    <color name="gradient_end">#9B6BFF</color>
+
+    <!-- Nút + / FAB -->
+    <color name="fab_blue">#3D7BFF</color>
+
+    <!-- Accent bổ trợ -->
+    <color name="purple_200">#9B6BFF</color>
+    <color name="purple_500">#5A3EA6</color>
+    <color name="purple_700">#37215E</color>
+    <color name="teal_200">#5EEAD4</color>
+    <color name="teal_700">#1B5E5A</color>
+
+    <!-- Trạng thái / biểu đồ tuần -->
+    <color name="selected_color">#4B2F91</color>
+    <color name="done_color">#5A3EA6</color>
+    <color name="weekly_bar">#5A3EA6</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -4,19 +4,27 @@
     <!-- Cơ bản -->
     <color name="black">#000000</color>
     <color name="white">#FFFFFF</color>
+    <color name="white_soft">#F7F9FC</color>
 
     <!-- Nền ứng dụng -->
-    <color name="bg_dark">#181A20</color>      <!-- Background 01 -->
-    <color name="card_dark">#1F222A</color>    <!-- Background 02 / Surface -->
+    <color name="bg_dark">#F5F7FE</color>      <!-- Background 01 (light default) -->
+    <color name="card_dark">#FFFFFF</color>    <!-- Background 02 / Surface -->
+
+    <color name="background_primary">@color/white_soft</color>
+    <color name="background_surface">@color/white</color>
 
     <!-- Text -->
-    <color name="text_white">#FFFFFF</color>
-    <color name="text_gray">#B0B3B8</color>
+    <color name="text_white">#181A20</color>
+    <color name="text_gray">#5F6368</color>
+    <color name="text_primary_color">#181A20</color>
+    <color name="text_secondary_color">#5F6368</color>
     <color name="text_highlight">#FFD700</color> <!-- số/nhấn -->
+
+    <color name="outline_neutral">#1A000000</color>
 
     <!-- Tab / Điều hướng -->
     <color name="tab_inactive">#808080</color>
-    <color name="tab_active">#FFFFFF</color>
+    <color name="tab_active">#3D7BFF</color>
     <color name="tab_blue">#3D7BFF</color>      <!-- PRIMARY từ palette -->
 
     <!-- Primary / Secondary (theo “Main Colors”) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="task_reminder_body_date">Ngày %1$s • Chạm để mở</string>
     <string name="task_reminder_body_default">Chạm để xem chi tiết công việc</string>
     <string name="task_notification_permission_rationale">Ứng dụng cần quyền để gửi thông báo nhắc việc.</string>
+    <string name="settings_theme_title">Chế độ tối</string>
+    <string name="settings_theme_subtitle">Chuyển đổi giữa giao diện tối và sáng</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a ThemeUtils helper to persist the dark mode flag and apply it across launches
- surface a Material switch in Settings so users can toggle between light and dark themes
- refresh color resources, backgrounds, and button styling so light mode uses the new palette while dark mode keeps the existing tones

## Testing
- `./gradlew lint` *(fails: Gradle distribution download blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68f2fff1a8cc8325929306462e54fe61