### PR TITLE
Add task start notifications

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:allowBackup="true"
@@ -23,6 +24,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".notifications.TaskReminderReceiver"
+            android:exported="false" />
 
 
         <meta-data

--- a/app/src/main/java/com/example/appmanagement/notifications/NotificationScheduler.kt
+++ b/app/src/main/java/com/example/appmanagement/notifications/NotificationScheduler.kt
@@ -1,0 +1,62 @@
+package com.example.appmanagement.notifications
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+/**
+ * Hỗ trợ đặt Alarm tới đúng giờ bắt đầu của task để hiển thị Notification.
+ */
+object NotificationScheduler {
+    private val dateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
+    private val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+    fun scheduleTaskReminder(
+        context: Context,
+        taskId: Long,
+        title: String,
+        date: String,
+        startTime: String
+    ) {
+        val triggerAtMillis = parseDateTime(date, startTime) ?: return
+        if (triggerAtMillis <= System.currentTimeMillis()) return
+
+        val intent = Intent(context, TaskReminderReceiver::class.java).apply {
+            putExtra(TaskReminderReceiver.EXTRA_TASK_ID, taskId)
+            putExtra(TaskReminderReceiver.EXTRA_TITLE, title)
+            putExtra(TaskReminderReceiver.EXTRA_START_TIME, startTime)
+        }
+
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        val pendingIntent = PendingIntent.getBroadcast(
+            context,
+            taskId.toInt(),
+            intent,
+            flags
+        )
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+        } else {
+            alarmManager.setExact(AlarmManager.RTC_WAKEUP, triggerAtMillis, pendingIntent)
+        }
+    }
+
+    private fun parseDateTime(date: String, time: String): Long? = try {
+        val dateObj = LocalDate.parse(date, dateFormatter)
+        val timeObj = LocalTime.parse(time, timeFormatter)
+        val dateTime = LocalDateTime.of(dateObj, timeObj)
+        dateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    } catch (_: DateTimeParseException) {
+        null
+    }
+}

--- a/app/src/main/java/com/example/appmanagement/notifications/TaskReminderReceiver.kt
+++ b/app/src/main/java/com/example/appmanagement/notifications/TaskReminderReceiver.kt
@@ -1,0 +1,83 @@
+package com.example.appmanagement.notifications
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.media.AudioAttributes
+import android.media.RingtoneManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
+import com.example.appmanagement.R
+import com.example.appmanagement.ui.main.MainActivity
+
+/**
+ * BroadcastReceiver hiển thị thông báo khi đến giờ bắt đầu của 1 task.
+ * Được kích hoạt bởi [NotificationScheduler].
+ */
+class TaskReminderReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val taskId = intent.getLongExtra(EXTRA_TASK_ID, 0L)
+        val title = intent.getStringExtra(EXTRA_TITLE).orEmpty()
+        val startTime = intent.getStringExtra(EXTRA_START_TIME).orEmpty()
+
+        createChannelIfNeeded(context)
+
+        val contentIntent = TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(Intent(context, MainActivity::class.java))
+            getPendingIntent(taskId.toInt(), PendingIntent.FLAG_IMMUTABLE)
+        }
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_clock)
+            .setContentTitle(context.getString(R.string.app_name))
+            .setContentText("${context.getString(R.string.notify_task_start_prefix)} $title ($startTime)")
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .setContentIntent(contentIntent)
+            .build()
+
+        NotificationManagerCompat.from(context).notify(taskId.toInt(), notification)
+    }
+
+    private fun createChannelIfNeeded(context: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val existing = notificationManager.getNotificationChannel(CHANNEL_ID)
+        if (existing != null) return
+
+        val soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.notify_task_channel_name),
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            enableVibration(true)
+            enableLights(true)
+            setSound(
+                soundUri,
+                AudioAttributes.Builder()
+                    .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+                    .build()
+            )
+            description = context.getString(R.string.notify_task_channel_desc)
+        }
+
+        notificationManager.createNotificationChannel(channel)
+    }
+
+    companion object {
+        const val CHANNEL_ID = "task_start_time_channel"
+        const val EXTRA_TASK_ID = "extra_task_id"
+        const val EXTRA_TITLE = "extra_title"
+        const val EXTRA_START_TIME = "extra_start_time"
+    }
+}

--- a/app/src/main/java/com/example/appmanagement/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/main/MainActivity.kt
@@ -4,6 +4,7 @@ package com.example.appmanagement.ui.main
 import android.os.Bundle
 import android.view.View
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -58,6 +59,24 @@ class MainActivity : AppCompatActivity() {
         navController.addOnDestinationChangedListener { _, destination, _ ->
             binding.bottomNav.visibility =
                 if (destination.id in topLevelDestinations) View.VISIBLE else View.GONE
+        }
+
+        requestNotificationPermissionIfNeeded()
+    }
+
+    private val requestPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* ignore result */ }
+
+    private fun requestNotificationPermissionIfNeeded() {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.TIRAMISU) return
+
+        val permission = android.Manifest.permission.POST_NOTIFICATIONS
+        val granted = androidx.core.content.ContextCompat.checkSelfPermission(
+            this,
+            permission
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        if (!granted) {
+            requestPermissionLauncher.launch(permission)
         }
     }
 }

--- a/app/src/main/java/com/example/appmanagement/ui/menu/AddFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/AddFragment.kt
@@ -16,6 +16,7 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.databinding.FragmentAddBinding
+import com.example.appmanagement.notifications.NotificationScheduler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -136,6 +137,15 @@ class AddFragment : Fragment() {
 
             val insertedId = withContext(Dispatchers.IO) { db.taskDao().insert(task) }
             if (insertedId > 0) {
+                if (startObj != null && dateObj != null) {
+                    NotificationScheduler.scheduleTaskReminder(
+                        context = requireContext().applicationContext,
+                        taskId = insertedId,
+                        title = title,
+                        date = date,
+                        startTime = start
+                    )
+                }
                 Toast.makeText(requireContext(), "Đã thêm công việc", Toast.LENGTH_SHORT).show()
                 findNavController().navigate(R.id.action_addFragment_to_homeFragment)
             } else {

--- a/app/src/main/java/com/example/appmanagement/ui/menu/EditFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/EditFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.databinding.FragmentEditBinding
+import com.example.appmanagement.notifications.NotificationScheduler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -69,6 +70,7 @@ class EditFragment : Fragment() {
             val start = binding.edtStartTime.text?.toString()?.trim().orEmpty()
             val end = binding.edtEndTime.text?.toString()?.trim().orEmpty()
             val completed = binding.switchCompleted.isChecked  // Lấy trạng thái hoàn thành từ switch
+            val appContext = requireContext().applicationContext
 
             if (title.isBlank()) {
                 binding.edtTitle.error = "Vui lòng nhập tiêu đề"
@@ -90,6 +92,15 @@ class EditFragment : Fragment() {
                     isCompleted = completed   // Lưu trạng thái hoàn thành khi cập nhật
                 )
                 taskDao.update(updated)
+                if (start.isNotBlank()) {
+                    NotificationScheduler.scheduleTaskReminder(
+                        context = appContext,
+                        taskId = updated.id,
+                        title = title,
+                        date = date,
+                        startTime = start
+                    )
+                }
                 withContext(Dispatchers.Main) { findNavController().navigateUp() }
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="setting_dark_mode">Chế độ tối</string>
     <string name="setting_light_mode">Chế độ sáng</string>
 
-
-
+    <string name="notify_task_channel_name">Nhắc giờ bắt đầu</string>
+    <string name="notify_task_channel_desc">Báo khi đến giờ bắt đầu của công việc</string>
+    <string name="notify_task_start_prefix">Đã đến giờ bắt đầu</string>
 </resources>


### PR DESCRIPTION
## Summary
- add alarm-based scheduler and broadcast receiver to show task start notifications with sound
- trigger reminders when tasks are created or updated with start times
- declare notification channel strings and permissions for delivery
- request POST_NOTIFICATIONS at runtime on Android 13+ when the main activity launches

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ad49dd9ec832595cb231e8725e0f2)