### PR TITLE
Add Firestore sync for tasks and user remote IDs

### DIFF
--- a/app/src/main/java/com/example/appmanagement/data/dao/TaskDao.kt
+++ b/app/src/main/java/com/example/appmanagement/data/dao/TaskDao.kt
@@ -16,6 +16,9 @@ interface TaskDao {
     @Query("SELECT * FROM tasks WHERE user_id = :userId ORDER BY id DESC")
     fun getByUser(userId: Long): LiveData<List<Task>>
 
+    @Query("SELECT * FROM tasks WHERE user_id = :userId ORDER BY task_date, start_time, order_index")
+    fun observeTasksByUserId(userId: Long): LiveData<List<Task>>
+
     // LiveData theo id (nullable để dễ check null khi observe)
     @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
     fun getByIdLive(id: Long): LiveData<Task?>
@@ -23,6 +26,9 @@ interface TaskDao {
     // Dùng trong coroutine (IO) để lấy 1 lần
     @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
     suspend fun getByIdOnce(id: Long): Task?
+
+    @Query("SELECT * FROM tasks WHERE remote_id = :remoteId LIMIT 1")
+    suspend fun getByRemoteId(remoteId: String): Task?
 
     // Lọc theo trạng thái
     @Query("SELECT * FROM tasks WHERE user_id = :userId AND is_completed = 0 ORDER BY id DESC")

--- a/app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt
+++ b/app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt
@@ -1,0 +1,60 @@
+package com.example.appmanagement.data.remote
+
+import com.example.appmanagement.data.entity.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.FirebaseFirestore
+
+class TaskRemoteDataSource(
+    private val firestore: FirebaseFirestore
+) {
+
+    private val collection get() = firestore.collection("tasks")
+
+    suspend fun upsertTask(userRemoteId: String, task: Task): String {
+        val data = mapOf(
+            "userId" to userRemoteId,
+            "title" to task.title,
+            "description" to task.description,
+            "isCompleted" to task.isCompleted,
+            "taskDate" to task.taskDate,
+            "startTime" to task.startTime,
+            "endTime" to task.endTime,
+            "orderIndex" to task.orderIndex,
+            "createdAt" to task.createdAt,
+            "updatedAt" to task.updatedAt
+        )
+
+        return if (task.remoteId.isNullOrBlank()) {
+            val docRef = Tasks.await(collection.add(data))
+            docRef.id
+        } else {
+            Tasks.await(collection.document(task.remoteId).set(data))
+            task.remoteId
+        }
+    }
+
+    suspend fun deleteTask(remoteId: String) {
+        Tasks.await(collection.document(remoteId).delete())
+    }
+
+    suspend fun fetchTasks(userRemoteId: String): List<Task> {
+        val snapshot = Tasks.await(collection.whereEqualTo("userId", userRemoteId).get())
+        return snapshot.documents.map { doc ->
+            val data = doc.data.orEmpty()
+            Task(
+                id = 0,
+                userId = 0,
+                remoteId = doc.id,
+                title = data["title"] as? String ?: "",
+                description = data["description"] as? String ?: "",
+                isCompleted = data["isCompleted"] as? Boolean ?: false,
+                taskDate = data["taskDate"] as? String ?: "",
+                startTime = data["startTime"] as? String ?: "",
+                endTime = data["endTime"] as? String ?: "",
+                orderIndex = (data["orderIndex"] as? Long ?: 0L).toInt(),
+                createdAt = data["createdAt"] as? Long ?: System.currentTimeMillis(),
+                updatedAt = data["updatedAt"] as? Long ?: System.currentTimeMillis()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/appmanagement/data/viewmodel/TaskViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/data/viewmodel/TaskViewModel.kt
@@ -5,12 +5,14 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
+import com.example.appmanagement.data.entity.User
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -22,10 +24,16 @@ import kotlin.math.roundToInt
 class TaskViewModel(application: Application) : AndroidViewModel(application) {
 
     private val database by lazy { AppDatabase.getInstance(application) }
-    private val taskRepository by lazy { TaskRepository(database.taskDao()) }
+    private val taskRepository by lazy {
+        TaskRepository(
+            database.taskDao(),
+            database.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
+    }
     private val accountRepository by lazy { AccountRepository(database.userDao()) }
 
-    private val currentUserId = MutableLiveData<Long?>()
+    private var currentUser: User? = null
 
     private val _tasksAll = MediatorLiveData<List<Task>>()
     val tasksAll: LiveData<List<Task>> get() = _tasksAll
@@ -46,54 +54,62 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     private val _weekPercents = MediatorLiveData<IntArray>()  // [Mon..Sun] 0..100 theo trần 20
     val weekPercents: LiveData<IntArray> get() = _weekPercents
 
+    private var tasksAllSource: LiveData<List<Task>>? = null
+    private var tasksTodoSource: LiveData<List<Task>>? = null
+    private var tasksDoneSource: LiveData<List<Task>>? = null
+    private var tasksByDateSource: LiveData<List<Task>>? = null
+
     init {
-        // 1) Nạp user đăng nhập hiện tại
-        loadCurrentUser()
-
-        // 2) Khi có userId -> gắn nguồn dữ liệu
-        _tasksAll.addSource(currentUserId) { uid ->
-            _tasksAll.value = emptyList()
-            if (uid != null) {
-                val src = taskRepository.all(uid)
-                _tasksAll.addSource(src) { list ->
-                    _tasksAll.value = list
-                    // Mỗi lần all tasks đổi -> cập nhật dữ liệu tuần
-                    computeWeeklySeries(list.orEmpty())
-                }
-            }
-        }
-
-        _tasksTodo.addSource(currentUserId) { uid ->
-            _tasksTodo.value = emptyList()
-            if (uid != null) {
-                val src = taskRepository.uncompleted(uid)
-                _tasksTodo.addSource(src) { _tasksTodo.value = it }
-            }
-        }
-
-        _tasksDone.addSource(currentUserId) { uid ->
-            _tasksDone.value = emptyList()
-            if (uid != null) {
-                val src = taskRepository.completed(uid)
-                _tasksDone.addSource(src) { _tasksDone.value = it }
-            }
-        }
-        // _tasksByDate gắn nguồn khi filterByDate(...)
+        loadTasksForCurrentUser()
     }
 
-    private fun loadCurrentUser() = viewModelScope.launch {
+    fun loadTasksForCurrentUser() = viewModelScope.launch {
         val user = withContext(Dispatchers.IO) { accountRepository.getCurrentUser() }
-        currentUserId.value = user?.id
+        currentUser = user
+        attachSources(user)
+    }
+
+    private fun attachSources(user: User?) {
+        tasksAllSource?.let { _tasksAll.removeSource(it) }
+        tasksTodoSource?.let { _tasksTodo.removeSource(it) }
+        tasksDoneSource?.let { _tasksDone.removeSource(it) }
+
+        _tasksAll.value = emptyList()
+        _tasksTodo.value = emptyList()
+        _tasksDone.value = emptyList()
+        computeWeeklySeries(emptyList())
+
+        if (user == null) return
+
+        taskRepository.observeTasksByUserId(user.id).also { source ->
+            tasksAllSource = source
+            _tasksAll.addSource(source) { list ->
+                _tasksAll.value = list
+                computeWeeklySeries(list.orEmpty())
+            }
+        }
+
+        taskRepository.uncompleted(user.id).also { source ->
+            tasksTodoSource = source
+            _tasksTodo.addSource(source) { _tasksTodo.value = it }
+        }
+
+        taskRepository.completed(user.id).also { source ->
+            tasksDoneSource = source
+            _tasksDone.addSource(source) { _tasksDone.value = it }
+        }
     }
 
     /** Lọc theo ngày */
     fun filterByDate(date: String) {
-        val uid = currentUserId.value ?: run {
+        val user = currentUser ?: run {
             _tasksByDate.value = emptyList()
             return
         }
         _tasksByDate.value = emptyList()
-        val source = taskRepository.byDate(uid, date)
+        tasksByDateSource?.let { _tasksByDate.removeSource(it) }
+        val source = taskRepository.byDate(user.id, date)
+        tasksByDateSource = source
         _tasksByDate.addSource(source) { _tasksByDate.value = it }
     }
 
@@ -105,8 +121,8 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
         startTime: String,
         endTime: String
     ) = viewModelScope.launch(Dispatchers.IO) {
-        val uid = currentUserId.value ?: return@launch
-        taskRepository.add(uid, title, description, taskDate, startTime, endTime)
+        val user = getCurrentUserSafe() ?: return@launch
+        taskRepository.add(user.id, title, description, taskDate, startTime, endTime)
     }
 
     /** Cập nhật Task */
@@ -122,6 +138,11 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     /** Đổi trạng thái hoàn thành */
     fun toggleTask(task: Task) = viewModelScope.launch(Dispatchers.IO) {
         taskRepository.toggle(task)
+    }
+
+    fun syncTasksForCurrentUser() = viewModelScope.launch(Dispatchers.IO) {
+        val user = getCurrentUserSafe() ?: return@launch
+        taskRepository.syncFromRemote(user)
     }
 
     // ------------------ WEEKLY CHART HELPERS ------------------
@@ -168,5 +189,13 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
             // if (counts[i] > 0) maxOf(raw, 5) else 0
             (clamped * 100f / capPerDay).roundToInt()
         }
+    }
+
+    private suspend fun getCurrentUserSafe(): User? {
+        val cached = currentUser
+        if (cached != null) return cached
+        val refreshed = withContext(Dispatchers.IO) { accountRepository.getCurrentUser() }
+        currentUser = refreshed
+        return refreshed
     }
 }

--- a/app/src/main/java/com/example/appmanagement/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/home/HomeFragment.kt
@@ -57,6 +57,9 @@ class HomeFragment : Fragment() {
 
         showCards(true)
 
+        vm.loadTasksForCurrentUser()
+        vm.syncTasksForCurrentUser()
+
         val db = AppDatabase.getInstance(requireContext())
         val repo = AccountRepository(db.userDao())
 

--- a/app/src/main/java/com/example/appmanagement/ui/menu/CalendarFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/CalendarFragment.kt
@@ -13,8 +13,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentCalendarBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -63,7 +65,11 @@ class CalendarFragment : Fragment() {
         // Khởi tạo DB + Repo
         val database = AppDatabase.getInstance(requireContext().applicationContext)
         accountRepository = AccountRepository(database.userDao())
-        taskRepository = TaskRepository(database.taskDao())
+        taskRepository = TaskRepository(
+            database.taskDao(),
+            database.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         // Khởi tạo adapter (đã là working list)
         taskAdapter = TaskAdapter(

--- a/app/src/main/java/com/example/appmanagement/ui/menu/DoneFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/DoneFragment.kt
@@ -14,8 +14,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.R
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentDoneBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -46,7 +48,11 @@ class DoneFragment : Fragment() {
         val appContext = requireContext().applicationContext
         val db = AppDatabase.getInstance(appContext)
         val accountRepo = AccountRepository(db.userDao())
-        taskRepo = TaskRepository(db.taskDao())
+        taskRepo = TaskRepository(
+            db.taskDao(),
+            db.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         taskAdapter = TaskAdapter(
             onEditClick = { task ->

--- a/app/src/main/java/com/example/appmanagement/ui/menu/ListFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/ListFragment.kt
@@ -12,8 +12,10 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentListBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -45,7 +47,11 @@ class ListFragment : Fragment() {
         val appContext = requireContext().applicationContext
         val db = AppDatabase.getInstance(appContext)
         val accountRepo = AccountRepository(db.userDao())
-        taskRepo = TaskRepository(db.taskDao())
+        taskRepo = TaskRepository(
+            db.taskDao(),
+            db.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         taskAdapter = TaskAdapter(
             onEditClick = { task ->

--- a/app/src/main/java/com/example/appmanagement/ui/menu/TodayFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/TodayFragment.kt
@@ -14,8 +14,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.R
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentTodayBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -51,7 +53,11 @@ class TodayFragment : Fragment() {
         val appContext = requireContext().applicationContext
         val db = AppDatabase.getInstance(appContext)
         val accountRepo = AccountRepository(db.userDao())
-        taskRepo = TaskRepository(db.taskDao())
+        taskRepo = TaskRepository(
+            db.taskDao(),
+            db.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         taskAdapter = TaskAdapter(
             onEditClick = { task ->

--- a/app/src/main/java/com/example/appmanagement/ui/onboard/OnboardFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/onboard/OnboardFragment.kt
@@ -8,10 +8,12 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.example.appmanagement.R
 import com.example.appmanagement.data.viewmodel.SignInViewModel
+import com.example.appmanagement.data.viewmodel.TaskViewModel
 import com.example.appmanagement.databinding.FragmentOnboardBinding
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInAccount
@@ -27,6 +29,7 @@ class OnboardFragment : Fragment() {
 
     // ViewModel lưu user vào Room
     private val viewModel: SignInViewModel by viewModels()
+    private val taskViewModel: TaskViewModel by activityViewModels()
 
     private lateinit var auth: FirebaseAuth
     private lateinit var googleSignInClient: com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -109,6 +112,7 @@ class OnboardFragment : Fragment() {
                     firebaseUser = firebaseUser,
                     onSuccess = { user ->
                         toast("Xin chào ${user.name}!")
+                        taskViewModel.syncTasksForCurrentUser()
                         findNavController().navigate(R.id.homeFragment)
                     },
                     onError = {

--- a/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
@@ -11,6 +11,8 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -18,7 +20,13 @@ import kotlinx.coroutines.withContext
 class TaskViewModel(application: Application) : AndroidViewModel(application) {
 
     private val database by lazy { AppDatabase.getInstance(application) }
-    private val taskRepository by lazy { TaskRepository(database.taskDao()) }
+    private val taskRepository by lazy {
+        TaskRepository(
+            database.taskDao(),
+            database.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
+    }
     private val accountRepository by lazy { AccountRepository(database.userDao()) }
 
     private val currentUserId = MutableLiveData<Long?>()


### PR DESCRIPTION
## Summary
- add a Firebase-backed TaskRemoteDataSource and wire TaskRepository to sync create/update/delete/order changes using remoteId and updatedAt
- extend TaskDao and TaskViewModel to observe tasks per user, merge remote data, and expose a sync trigger after Google sign-in
- update onboarding and task-related fragments to construct TaskRepository with Firestore support and ensure tasks load/sync on entry

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201347ddb883259bcdcbc20b697bf6)