### PR TITLE
Handle Google re-login flow and reset task session

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,63 @@
-# Ứng dụng AppManagement (Todo App)
+# AppManagement (Todo App)
 
-## Giới thiệu
-Ứng dụng AppManagement là một mẫu ứng dụng quản lý công việc viết bằng Kotlin cho nền tảng Android. Dự án được xây dựng nhằm minh họa các luồng đăng nhập, đăng ký, quản lý hồ sơ người dùng cũng như tạo và theo dõi danh sách công việc hằng ngày. Mã nguồn đã được bổ sung chú thích bằng tiếng Việt để giúp việc đọc hiểu cấu trúc dự án trở nên trực quan hơn.
+Ứng dụng AppManagement là một mẫu **quản lý công việc** viết bằng Kotlin cho Android. Mã nguồn minh họa đầy đủ các lớp ViewModel, Repository, Room, Firestore và điều hướng Fragment để triển khai luồng đăng nhập, tạo–đồng bộ công việc và thống kê tuần.
 
-## Tính năng chính
-- Quy trình onboarding, splash và tự động chuyển hướng dựa trên trạng thái đăng nhập.
-- Đăng ký, đăng nhập bằng email, lưu mật khẩu dạng BCrypt và duy trì trạng thái người dùng trong cơ sở dữ liệu.
-- Tạo, chỉnh sửa, sắp xếp và đánh dấu hoàn thành cho công việc với dữ liệu lưu bằng Room.
-- Bộ lọc công việc theo ngày, danh sách hôm nay, danh sách đã hoàn thành và chức năng tìm kiếm theo từ khóa.
-- Đồng hồ bấm giờ có lưu các mốc thời gian và khả năng tiếp tục khi quay lại màn hình.
-- Giao diện thống kê với biểu đồ cột thể hiện số lượng công việc hoàn thành trong tuần.
+## Kiến trúc tổng quan
+Ứng dụng tách rõ ba tầng chính:
 
-## Công nghệ và thư viện
-- **Ngôn ngữ:** Kotlin với Gradle Kotlin DSL.
-- **UI:** Fragment, ViewBinding, Material Components.
-- **Điều hướng:** Jetpack Navigation Component và Safe Args.
-- **Lưu trữ:** Room Database, LiveData và ViewModel.
-- **Bảo mật:** BCrypt để băm mật khẩu, SQLCipher/EncryptedSharedPreferences đã khai báo trong phụ thuộc.
-- **Khác:** Coroutine (Dispatchers.IO) cho xử lý bất đồng bộ, Handler cho đồng hồ bấm giờ.
+- **Data layer**
+  - `data/entity` chứa các **Room entity**: `User` (thông tin tài khoản, trạng thái đăng nhập, `remoteId` để đồng bộ Google/Firebase) và `Task` (công việc gắn user, trạng thái hoàn thành, `remoteId`, `updatedAt`).
+  - `data/dao` định nghĩa **DAO** cho CRUD và truy vấn nâng cao: `UserDao` quản lý đăng nhập, đổi thông tin và tìm theo `remoteId`; `TaskDao` cung cấp lọc theo user/ngày/trạng thái, cập nhật `orderIndex`, tìm theo `remoteId`.
+  - `data/db/AppDatabase` cấu hình Room (phiên bản 2) với **migration 1→2** để bổ sung cột `remote_id`/`updated_at` cho cả `users` và `tasks`.
+  - `data/remote/TaskRemoteDataSource` là **adapter Firestore**: thêm/cập nhật/xóa task (document collection `tasks`), ánh xạ trường `taskDate`, `orderIndex`, `updatedAt`… và truy vấn danh sách theo `userId` (uid Firebase).
+  - `data/repo` gom logic nghiệp vụ: `AccountRepository` xử lý đăng ký/login email (BCrypt hash), đăng nhập Google dựa trên `uid` và lưu `remoteId`; `TaskRepository` thao tác Room + Firestore (tạo/sửa/xóa, đổi thứ tự, đồng bộ hai chiều theo `updatedAt`, gán `remoteId` sau khi upsert).
 
-## Cấu trúc thư mục nổi bật
-- `app/src/main/java/com/example/appmanagement/ui` – Chứa các Fragment hiển thị giao diện chính và logic tương tác.
-- `app/src/main/java/com/example/appmanagement/data` – Bao gồm entity, DAO, repository và ViewModel phục vụ dữ liệu.
-- `app/src/main/res` – Tập hợp layout, drawable, navigation và tài nguyên cấu hình.
-- `app/src/main/AndroidManifest.xml` – Khai báo activity, quyền và meta-data của ứng dụng.
+- **ViewModel layer**
+  - `data/viewmodel/SignInViewModel` điều phối đăng nhập/đăng ký và đăng nhập Google thông qua `AccountRepository`.
+  - `data/viewmodel/TaskViewModel` giữ state danh sách task (toàn bộ, chưa xong, đã xong, theo ngày), tính thống kê 7 ngày và cung cấp trigger `syncTasksForCurrentUser()` để kéo dữ liệu Firestore về Room.
+  - `data/viewmodel/CreateWorkViewModel` hỗ trợ form tạo/sửa công việc, truy vấn task theo `id`.
 
-## Chuẩn bị môi trường
-1. Cài đặt **Android Studio Flamingo** (hoặc mới hơn) với Android SDK 36 và công cụ build tương ứng.
-2. Đồng bộ dự án bằng Gradle Wrapper (`./gradlew tasks`) để tải các phụ thuộc cần thiết.
-3. Nếu cần sử dụng dịch vụ Firebase/Facebook, cập nhật lại tệp `google-services.json` và các khóa ứng dụng tương ứng.
+- **UI layer (Fragments)**
+  - **Onboarding** (`ui/onboard/OnboardFragment`): cho phép chọn đăng nhập bằng email hoặc Google. Khi đăng nhập Google thành công, `SignInViewModel.loginWithGoogleUser` lưu user vào Room rồi gọi `TaskViewModel.syncTasksForCurrentUser()` trước khi điều hướng sang màn chính.
+  - **Đăng nhập/đăng ký** (`ui/login`): màn email/password gọi `SignInViewModel.login` hoặc `register` rồi chuyển sang Home khi thành công.
+  - **Trang chủ** (`ui/home/HomeFragment`): quan sát `TaskViewModel.tasksAll` để hiển thị thống kê hôm nay, biểu đồ tuần, tìm kiếm; tự `loadTasksForCurrentUser()` và `syncTasksForCurrentUser()` khi vào màn.
+  - **Menu công việc** (`ui/menu`): các tab Today/List/Calendar/Done quan sát dữ liệu lọc từ `TaskViewModel` và mở form chỉnh sửa khi cần.
+  - **Tạo/Chỉnh sửa task** (`ui/task`): dùng `TaskViewModel` để thêm mới, cập nhật, toggle hoàn thành; các thao tác đều chạy trong coroutine `Dispatchers.IO`.
+  - **Splash/Main** (`ui/splash`, `ui/main`): khởi động app, điều hướng vào Onboard hoặc Home tùy trạng thái đăng nhập.
 
-## Cách chạy ứng dụng
-1. Mở dự án trong Android Studio.
-2. Chọn một thiết bị ảo (API 33+) hoặc thiết bị thật có kích thước màn hình tối thiểu tương đương.
-3. Nhấn **Run** (Shift + F10) để biên dịch và cài đặt ứng dụng.
-4. Ở lần chạy đầu tiên, thực hiện quy trình onboarding → nhập email → đăng ký để tạo tài khoản mẫu.
+- **Tiện ích & bảo mật**
+  - `util/Security` cung cấp hàm hash/verify BCrypt cho mật khẩu local.
+  - `uitls/WeekChart` (và các extension ngày giờ) hỗ trợ tính toán + vẽ biểu đồ tuần.
+  - `notifications` chứa code hiển thị thông báo nhắc việc khi cần.
 
-## Kiểm thử cơ bản
-- Chạy `./gradlew lint` để kiểm tra quy tắc mã nguồn.
-- Sử dụng `./gradlew test` để chạy các bài kiểm thử đơn vị (nếu có trong thư mục `app/src/test`).
-- Kiểm tra thủ công các luồng chính: đăng ký, đăng nhập, tạo công việc, chỉnh sửa, đánh dấu hoàn thành và sử dụng đồng hồ bấm giờ.
+## Luồng hoạt động chính
+1. **Khởi chạy ứng dụng**: Splash kiểm tra user đang đăng nhập (Room `is_logged_in`). Nếu có, chuyển thẳng tới Home; nếu không, mở Onboarding.
+2. **Đăng nhập/Đăng ký email**: Form gọi `SignInViewModel`, repository xác thực mật khẩu hoặc tạo user mới (hash BCrypt), set cờ `is_logged_in` trong Room.
+3. **Đăng nhập Google**: Onboarding khởi chạy Google Sign-In → Firebase Auth trả `FirebaseUser` → `AccountRepository.loginWithGoogleAccount` tìm/tạo `User` với `remoteId = uid` và đánh dấu đăng nhập → TaskViewModel đồng bộ task với Firestore theo `remoteId`.
+4. **Quản lý công việc**:
+   - Thêm/Sửa/Xóa/Đổi thứ tự/Toggle hoàn thành: `TaskRepository` ghi Room, cập nhật `updatedAt` và (nếu user có `remoteId`) upsert/xóa trên Firestore; khi Firestore tạo document mới, `remoteId` được lưu lại vào Room.
+   - Lọc & thống kê: TaskViewModel xuất LiveData theo user hiện tại; biểu đồ tuần và thống kê hôm nay tính toán dựa trên danh sách `tasksAll`.
+5. **Đồng bộ đa thiết bị**: `syncFromRemote(User)` tải mọi task Firestore của `remoteId` hiện tại; mỗi task so sánh `updatedAt` với bản local để quyết định update/giữ nguyên, đảm bảo “bản mới nhất thắng” khi dùng cùng Gmail trên nhiều thiết bị.
 
-## Ghi chú
-- Mọi file nguồn đã được bổ sung chú thích tiếng Việt bằng ký hiệu `//` (hoặc `<!-- // ... -->` với XML) nhằm mô tả rõ mục đích và chức năng từng thành phần mà không ảnh hưởng đến logic hoạt động.
-- Khi triển khai thực tế, nên cấu hình lại giới hạn minSdk/targetSdk và tối ưu hóa dữ liệu sao lưu theo nhu cầu ứng dụng của bạn.
+## Thiết lập & chạy
+1. **Yêu cầu**: Android Studio Hedgehog/Flamingo+, JDK 17, Android SDK 33+.
+2. **Firebase**: đặt tệp `google-services.json` hợp lệ dưới `app/` để Google Sign-In + Firestore hoạt động; bật Authentication (Google) và Cloud Firestore trên console.
+3. **Đồng bộ phụ thuộc**: chạy `./gradlew tasks` hoặc Sync trong Android Studio.
+4. **Chạy ứng dụng**: chọn thiết bị ảo/thật (API 33+), bấm Run. Lần đầu mở app đi qua Onboard → đăng ký email hoặc đăng nhập Google → tạo công việc → thử đồng bộ bằng cách đăng nhập cùng Gmail ở thiết bị khác và gọi lại sync (Home tự gọi khi mở).
+
+## Kiểm thử nhanh
+- `./gradlew lint` – kiểm tra style và issue thường gặp.
+- `./gradlew test` – chạy test đơn vị (nếu có).
+- Kiểm thử thủ công: tạo task, đánh dấu hoàn thành, đổi thứ tự, đăng nhập Google trên hai thiết bị/AVD để xác nhận đồng bộ Firestore.
+
+## Cấu trúc thư mục rút gọn
+- `app/src/main/java/com/example/appmanagement/data/entity` – Entity `User`, `Task`.
+- `app/src/main/java/com/example/appmanagement/data/dao` – DAO Room.
+- `app/src/main/java/com/example/appmanagement/data/db/AppDatabase.kt` – cấu hình Room + migration.
+- `app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt` – API Firestore.
+- `app/src/main/java/com/example/appmanagement/data/repo` – Repository tài khoản và công việc.
+- `app/src/main/java/com/example/appmanagement/data/viewmodel` – ViewModel cho đăng nhập, công việc.
+- `app/src/main/java/com/example/appmanagement/ui` – Fragment UI (onboarding, login, home, menu, task, splash, main).
+- `app/src/main/java/com/example/appmanagement/util` & `uitls` – tiện ích chung.
+- `app/src/main/java/com/example/appmanagement/notifications` – logic thông báo.
+

--- a/app/src/main/java/com/example/appmanagement/data/dao/TaskDao.kt
+++ b/app/src/main/java/com/example/appmanagement/data/dao/TaskDao.kt
@@ -16,6 +16,9 @@ interface TaskDao {
     @Query("SELECT * FROM tasks WHERE user_id = :userId ORDER BY id DESC")
     fun getByUser(userId: Long): LiveData<List<Task>>
 
+    @Query("SELECT * FROM tasks WHERE user_id = :userId ORDER BY task_date, start_time, order_index")
+    fun observeTasksByUserId(userId: Long): LiveData<List<Task>>
+
     // LiveData theo id (nullable để dễ check null khi observe)
     @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
     fun getByIdLive(id: Long): LiveData<Task?>
@@ -23,6 +26,9 @@ interface TaskDao {
     // Dùng trong coroutine (IO) để lấy 1 lần
     @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
     suspend fun getByIdOnce(id: Long): Task?
+
+    @Query("SELECT * FROM tasks WHERE remote_id = :remoteId LIMIT 1")
+    suspend fun getByRemoteId(remoteId: String): Task?
 
     // Lọc theo trạng thái
     @Query("SELECT * FROM tasks WHERE user_id = :userId AND is_completed = 0 ORDER BY id DESC")

--- a/app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt
+++ b/app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt
@@ -1,0 +1,60 @@
+package com.example.appmanagement.data.remote
+
+import com.example.appmanagement.data.entity.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.firestore.FirebaseFirestore
+
+class TaskRemoteDataSource(
+    private val firestore: FirebaseFirestore
+) {
+
+    private val collection get() = firestore.collection("tasks")
+
+    suspend fun upsertTask(userRemoteId: String, task: Task): String {
+        val data = mapOf(
+            "userId" to userRemoteId,
+            "title" to task.title,
+            "description" to task.description,
+            "isCompleted" to task.isCompleted,
+            "taskDate" to task.taskDate,
+            "startTime" to task.startTime,
+            "endTime" to task.endTime,
+            "orderIndex" to task.orderIndex,
+            "createdAt" to task.createdAt,
+            "updatedAt" to task.updatedAt
+        )
+
+        return if (task.remoteId.isNullOrBlank()) {
+            val docRef = Tasks.await(collection.add(data))
+            docRef.id
+        } else {
+            Tasks.await(collection.document(task.remoteId).set(data))
+            task.remoteId
+        }
+    }
+
+    suspend fun deleteTask(remoteId: String) {
+        Tasks.await(collection.document(remoteId).delete())
+    }
+
+    suspend fun fetchTasks(userRemoteId: String): List<Task> {
+        val snapshot = Tasks.await(collection.whereEqualTo("userId", userRemoteId).get())
+        return snapshot.documents.map { doc ->
+            val data = doc.data.orEmpty()
+            Task(
+                id = 0,
+                userId = 0,
+                remoteId = doc.id,
+                title = data["title"] as? String ?: "",
+                description = data["description"] as? String ?: "",
+                isCompleted = data["isCompleted"] as? Boolean ?: false,
+                taskDate = data["taskDate"] as? String ?: "",
+                startTime = data["startTime"] as? String ?: "",
+                endTime = data["endTime"] as? String ?: "",
+                orderIndex = (data["orderIndex"] as? Long ?: 0L).toInt(),
+                createdAt = data["createdAt"] as? Long ?: System.currentTimeMillis(),
+                updatedAt = data["updatedAt"] as? Long ?: System.currentTimeMillis()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/appmanagement/data/repo/AccountRepository.kt
+++ b/app/src/main/java/com/example/appmanagement/data/repo/AccountRepository.kt
@@ -5,6 +5,11 @@ import com.example.appmanagement.data.dao.UserDao
 import com.example.appmanagement.data.entity.User
 import com.example.appmanagement.util.Security
 
+data class GoogleLoginResult(
+    val user: User,
+    val isExisting: Boolean
+)
+
 class AccountRepository(
     private val userDao: UserDao
 ) {
@@ -70,7 +75,7 @@ class AccountRepository(
         email: String?,
         name: String?,
         avatarUrl: String?
-    ): User {
+    ): GoogleLoginResult {
         val safeEmail = (email ?: "$uid@firebase.local").trim()
         val safeName = (name ?: safeEmail.substringBefore("@")).trim()
 
@@ -89,7 +94,7 @@ class AccountRepository(
                 updatedAt = System.currentTimeMillis()
             )
             userDao.update(updated)
-            updated
+            GoogleLoginResult(updated, true)
 
         } else {
             // lần đầu đăng nhập Google -> tạo user mới
@@ -107,7 +112,7 @@ class AccountRepository(
                 updatedAt = System.currentTimeMillis()
             )
             val newId = userDao.insert(newUser)
-            newUser.copy(id = newId)
+            GoogleLoginResult(newUser.copy(id = newId), false)
         }
     }
 

--- a/app/src/main/java/com/example/appmanagement/data/viewmodel/SignInViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/data/viewmodel/SignInViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.User
 import com.example.appmanagement.data.repo.AccountRepository
+import com.example.appmanagement.data.repo.GoogleLoginResult
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -78,12 +79,12 @@ class SignInViewModel(app: Application) : AndroidViewModel(app) {
     // loginWithGoogleUser – nhận FirebaseUser – gọi repo.loginWithGoogleAccount – trả User về callback
     fun loginWithGoogleUser(
         firebaseUser: FirebaseUser,
-        onSuccess: (User) -> Unit,
+        onSuccess: (User, Boolean) -> Unit,
         onError: (Throwable) -> Unit
     ) {
         viewModelScope.launch {
             try {
-                val user = withContext(Dispatchers.IO) {
+                val result: GoogleLoginResult = withContext(Dispatchers.IO) {
                     accountRepository.loginWithGoogleAccount(
                         uid = firebaseUser.uid,
                         email = firebaseUser.email,
@@ -91,7 +92,7 @@ class SignInViewModel(app: Application) : AndroidViewModel(app) {
                         avatarUrl = firebaseUser.photoUrl?.toString()
                     )
                 }
-                onSuccess(user)
+                onSuccess(result.user, result.isExisting)
             } catch (e: Throwable) {
                 onError(e)
             }

--- a/app/src/main/java/com/example/appmanagement/data/viewmodel/TaskViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/data/viewmodel/TaskViewModel.kt
@@ -5,12 +5,14 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
+import com.example.appmanagement.data.entity.User
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -22,10 +24,16 @@ import kotlin.math.roundToInt
 class TaskViewModel(application: Application) : AndroidViewModel(application) {
 
     private val database by lazy { AppDatabase.getInstance(application) }
-    private val taskRepository by lazy { TaskRepository(database.taskDao()) }
+    private val taskRepository by lazy {
+        TaskRepository(
+            database.taskDao(),
+            database.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
+    }
     private val accountRepository by lazy { AccountRepository(database.userDao()) }
 
-    private val currentUserId = MutableLiveData<Long?>()
+    private var currentUser: User? = null
 
     private val _tasksAll = MediatorLiveData<List<Task>>()
     val tasksAll: LiveData<List<Task>> get() = _tasksAll
@@ -46,54 +54,64 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     private val _weekPercents = MediatorLiveData<IntArray>()  // [Mon..Sun] 0..100 theo trần 20
     val weekPercents: LiveData<IntArray> get() = _weekPercents
 
+    private var tasksAllSource: LiveData<List<Task>>? = null
+    private var tasksTodoSource: LiveData<List<Task>>? = null
+    private var tasksDoneSource: LiveData<List<Task>>? = null
+    private var tasksByDateSource: LiveData<List<Task>>? = null
+
     init {
-        // 1) Nạp user đăng nhập hiện tại
-        loadCurrentUser()
-
-        // 2) Khi có userId -> gắn nguồn dữ liệu
-        _tasksAll.addSource(currentUserId) { uid ->
-            _tasksAll.value = emptyList()
-            if (uid != null) {
-                val src = taskRepository.all(uid)
-                _tasksAll.addSource(src) { list ->
-                    _tasksAll.value = list
-                    // Mỗi lần all tasks đổi -> cập nhật dữ liệu tuần
-                    computeWeeklySeries(list.orEmpty())
-                }
-            }
-        }
-
-        _tasksTodo.addSource(currentUserId) { uid ->
-            _tasksTodo.value = emptyList()
-            if (uid != null) {
-                val src = taskRepository.uncompleted(uid)
-                _tasksTodo.addSource(src) { _tasksTodo.value = it }
-            }
-        }
-
-        _tasksDone.addSource(currentUserId) { uid ->
-            _tasksDone.value = emptyList()
-            if (uid != null) {
-                val src = taskRepository.completed(uid)
-                _tasksDone.addSource(src) { _tasksDone.value = it }
-            }
-        }
-        // _tasksByDate gắn nguồn khi filterByDate(...)
+        loadTasksForCurrentUser()
     }
 
-    private fun loadCurrentUser() = viewModelScope.launch {
+    fun loadTasksForCurrentUser() = viewModelScope.launch {
         val user = withContext(Dispatchers.IO) { accountRepository.getCurrentUser() }
-        currentUserId.value = user?.id
+        currentUser = user
+        attachSources(user)
+    }
+
+    private fun attachSources(user: User?) {
+        tasksAllSource?.let { _tasksAll.removeSource(it) }
+        tasksTodoSource?.let { _tasksTodo.removeSource(it) }
+        tasksDoneSource?.let { _tasksDone.removeSource(it) }
+        tasksByDateSource?.let { _tasksByDate.removeSource(it) }
+
+        _tasksAll.value = emptyList()
+        _tasksTodo.value = emptyList()
+        _tasksDone.value = emptyList()
+        _tasksByDate.value = emptyList()
+        computeWeeklySeries(emptyList())
+
+        if (user == null) return
+
+        taskRepository.observeTasksByUserId(user.id).also { source ->
+            tasksAllSource = source
+            _tasksAll.addSource(source) { list ->
+                _tasksAll.value = list
+                computeWeeklySeries(list.orEmpty())
+            }
+        }
+
+        taskRepository.uncompleted(user.id).also { source ->
+            tasksTodoSource = source
+            _tasksTodo.addSource(source) { _tasksTodo.value = it }
+        }
+
+        taskRepository.completed(user.id).also { source ->
+            tasksDoneSource = source
+            _tasksDone.addSource(source) { _tasksDone.value = it }
+        }
     }
 
     /** Lọc theo ngày */
     fun filterByDate(date: String) {
-        val uid = currentUserId.value ?: run {
+        val user = currentUser ?: run {
             _tasksByDate.value = emptyList()
             return
         }
         _tasksByDate.value = emptyList()
-        val source = taskRepository.byDate(uid, date)
+        tasksByDateSource?.let { _tasksByDate.removeSource(it) }
+        val source = taskRepository.byDate(user.id, date)
+        tasksByDateSource = source
         _tasksByDate.addSource(source) { _tasksByDate.value = it }
     }
 
@@ -105,8 +123,8 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
         startTime: String,
         endTime: String
     ) = viewModelScope.launch(Dispatchers.IO) {
-        val uid = currentUserId.value ?: return@launch
-        taskRepository.add(uid, title, description, taskDate, startTime, endTime)
+        val user = getCurrentUserSafe() ?: return@launch
+        taskRepository.add(user.id, title, description, taskDate, startTime, endTime)
     }
 
     /** Cập nhật Task */
@@ -122,6 +140,11 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     /** Đổi trạng thái hoàn thành */
     fun toggleTask(task: Task) = viewModelScope.launch(Dispatchers.IO) {
         taskRepository.toggle(task)
+    }
+
+    fun syncTasksForCurrentUser() = viewModelScope.launch(Dispatchers.IO) {
+        val user = getCurrentUserSafe() ?: return@launch
+        taskRepository.syncFromRemote(user)
     }
 
     // ------------------ WEEKLY CHART HELPERS ------------------
@@ -168,5 +191,18 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
             // if (counts[i] > 0) maxOf(raw, 5) else 0
             (clamped * 100f / capPerDay).roundToInt()
         }
+    }
+
+    private suspend fun getCurrentUserSafe(): User? {
+        val cached = currentUser
+        if (cached != null) return cached
+        val refreshed = withContext(Dispatchers.IO) { accountRepository.getCurrentUser() }
+        currentUser = refreshed
+        return refreshed
+    }
+
+    fun clearSession() {
+        currentUser = null
+        attachSources(null)
     }
 }

--- a/app/src/main/java/com/example/appmanagement/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/home/HomeFragment.kt
@@ -57,6 +57,9 @@ class HomeFragment : Fragment() {
 
         showCards(true)
 
+        vm.loadTasksForCurrentUser()
+        vm.syncTasksForCurrentUser()
+
         val db = AppDatabase.getInstance(requireContext())
         val repo = AccountRepository(db.userDao())
 

--- a/app/src/main/java/com/example/appmanagement/ui/menu/CalendarFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/CalendarFragment.kt
@@ -13,8 +13,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentCalendarBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -63,7 +65,11 @@ class CalendarFragment : Fragment() {
         // Khởi tạo DB + Repo
         val database = AppDatabase.getInstance(requireContext().applicationContext)
         accountRepository = AccountRepository(database.userDao())
-        taskRepository = TaskRepository(database.taskDao())
+        taskRepository = TaskRepository(
+            database.taskDao(),
+            database.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         // Khởi tạo adapter (đã là working list)
         taskAdapter = TaskAdapter(

--- a/app/src/main/java/com/example/appmanagement/ui/menu/DoneFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/DoneFragment.kt
@@ -14,8 +14,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.R
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentDoneBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -46,7 +48,11 @@ class DoneFragment : Fragment() {
         val appContext = requireContext().applicationContext
         val db = AppDatabase.getInstance(appContext)
         val accountRepo = AccountRepository(db.userDao())
-        taskRepo = TaskRepository(db.taskDao())
+        taskRepo = TaskRepository(
+            db.taskDao(),
+            db.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         taskAdapter = TaskAdapter(
             onEditClick = { task ->

--- a/app/src/main/java/com/example/appmanagement/ui/menu/ListFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/ListFragment.kt
@@ -12,8 +12,10 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentListBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -45,7 +47,11 @@ class ListFragment : Fragment() {
         val appContext = requireContext().applicationContext
         val db = AppDatabase.getInstance(appContext)
         val accountRepo = AccountRepository(db.userDao())
-        taskRepo = TaskRepository(db.taskDao())
+        taskRepo = TaskRepository(
+            db.taskDao(),
+            db.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         taskAdapter = TaskAdapter(
             onEditClick = { task ->

--- a/app/src/main/java/com/example/appmanagement/ui/menu/SettingFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/SettingFragment.kt
@@ -7,16 +7,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.example.appmanagement.R
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.viewmodel.TaskViewModel
 import com.example.appmanagement.databinding.FragmentSettingBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import androidx.lifecycle.lifecycleScope
 import com.example.appmanagement.util.AppGlobals
 import com.example.appmanagement.util.ThemeManager
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
+import com.google.firebase.auth.FirebaseAuth
 
 import kotlinx.coroutines.launch
 
@@ -26,6 +31,7 @@ class SettingFragment : Fragment() {
     private val b get() = _binding!!
 
     private val args: SettingFragmentArgs by navArgs()
+    private val taskViewModel: TaskViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -94,6 +100,15 @@ class SettingFragment : Fragment() {
                 withContext(Dispatchers.IO) {
                     AppDatabase.getInstance(requireContext()).userDao().clearLoggedIn()
                 }
+
+                // sign out khỏi Google/Firebase để luôn hiện hộp chọn tài khoản khi đăng nhập lại
+                val gso = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                    .requestIdToken(getString(R.string.default_web_client_id))
+                    .requestEmail()
+                    .build()
+                GoogleSignIn.getClient(requireContext(), gso).signOut()
+                FirebaseAuth.getInstance().signOut()
+                taskViewModel.clearSession()
 
                 // reset biến toàn cục
                 AppGlobals.isLoggedIn = false

--- a/app/src/main/java/com/example/appmanagement/ui/menu/TodayFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/TodayFragment.kt
@@ -14,8 +14,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.example.appmanagement.R
 import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentTodayBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -51,7 +53,11 @@ class TodayFragment : Fragment() {
         val appContext = requireContext().applicationContext
         val db = AppDatabase.getInstance(appContext)
         val accountRepo = AccountRepository(db.userDao())
-        taskRepo = TaskRepository(db.taskDao())
+        taskRepo = TaskRepository(
+            db.taskDao(),
+            db.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
 
         taskAdapter = TaskAdapter(
             onEditClick = { task ->

--- a/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
@@ -11,6 +11,8 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
+import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -18,7 +20,13 @@ import kotlinx.coroutines.withContext
 class TaskViewModel(application: Application) : AndroidViewModel(application) {
 
     private val database by lazy { AppDatabase.getInstance(application) }
-    private val taskRepository by lazy { TaskRepository(database.taskDao()) }
+    private val taskRepository by lazy {
+        TaskRepository(
+            database.taskDao(),
+            database.userDao(),
+            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+        )
+    }
     private val accountRepository by lazy { AccountRepository(database.userDao()) }
 
     private val currentUserId = MutableLiveData<Long?>()


### PR DESCRIPTION
## Summary
- return Google sign-in results with an existing/new flag and route new accounts to profile setup after Firebase auth
- force account chooser on repeated Google sign-ins, reload/sync tasks for the freshly signed-in user, and clear task sources on logout
- sign out of Google/Firebase during logout so re-entry always prompts account selection

## Testing
- ./gradlew -q tasks >/dev/null

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69201347ddb883259bcdcbc20b697bf6)