### PR TITLE
Add Hilt DI and improve task-user sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("androidx.navigation.safeargs.kotlin")
     id("org.jetbrains.kotlin.kapt")
     id("com.google.gms.google-services")
+    id("com.google.dagger.hilt.android")
 }
 
 android {
@@ -109,4 +110,9 @@ dependencies {
 
     // Đăng nhập Google (nút Sign in with Google)
     implementation("com.google.android.gms:play-services-auth:21.2.0")
+
+    // Hilt (Dependency Injection)
+    implementation("com.google.dagger:hilt-android:2.52")
+    kapt("com.google.dagger:hilt-android-compiler:2.52")
+    implementation("androidx.hilt:hilt-navigation-fragment:1.2.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppManagement">
+        android:theme="@style/Theme.AppManagement"
+        android:name=".AppManagementApplication">
 
         <!-- Activity chính -->
         <activity

--- a/app/src/main/java/com/example/appmanagement/AppManagementApplication.kt
+++ b/app/src/main/java/com/example/appmanagement/AppManagementApplication.kt
@@ -1,0 +1,7 @@
+package com.example.appmanagement
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class AppManagementApplication : Application()

--- a/app/src/main/java/com/example/appmanagement/data/viewmodel/SignInViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/data/viewmodel/SignInViewModel.kt
@@ -1,24 +1,23 @@
 // ViewModel SignInViewModel xử lý đăng nhập và đăng ký bằng cách gọi AccountRepository trong coroutine
 package com.example.appmanagement.data.viewmodel
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.User
 import com.example.appmanagement.data.repo.AccountRepository
 import com.google.firebase.auth.FirebaseUser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class SignInViewModel(app: Application) : AndroidViewModel(app) {
-
-    // Data layer
-    private val database by lazy { AppDatabase.getInstance(app) }
-    private val accountRepository by lazy { AccountRepository(database.userDao()) }
+@HiltViewModel
+class SignInViewModel @Inject constructor(
+    private val accountRepository: AccountRepository
+) : ViewModel() {
 
     // Login result: true = success, false = failure
     private val _loginResult = MutableLiveData<Boolean>()

--- a/app/src/main/java/com/example/appmanagement/di/AppModule.kt
+++ b/app/src/main/java/com/example/appmanagement/di/AppModule.kt
@@ -1,0 +1,53 @@
+package com.example.appmanagement.di
+
+import android.content.Context
+import com.example.appmanagement.data.dao.TaskDao
+import com.example.appmanagement.data.dao.UserDao
+import com.example.appmanagement.data.db.AppDatabase
+import com.example.appmanagement.data.remote.TaskRemoteDataSource
+import com.example.appmanagement.data.repo.AccountRepository
+import com.example.appmanagement.data.repo.TaskRepository
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideDatabase(@ApplicationContext context: Context): AppDatabase =
+        AppDatabase.getInstance(context)
+
+    @Provides
+    fun provideUserDao(db: AppDatabase): UserDao = db.userDao()
+
+    @Provides
+    fun provideTaskDao(db: AppDatabase): TaskDao = db.taskDao()
+
+    @Provides
+    @Singleton
+    fun provideTaskRemoteDataSource(firestore: FirebaseFirestore): TaskRemoteDataSource =
+        TaskRemoteDataSource(firestore)
+
+    @Provides
+    @Singleton
+    fun provideTaskRepository(
+        taskDao: TaskDao,
+        userDao: UserDao,
+        remoteDataSource: TaskRemoteDataSource
+    ): TaskRepository = TaskRepository(taskDao, userDao, remoteDataSource)
+
+    @Provides
+    @Singleton
+    fun provideAccountRepository(userDao: UserDao): AccountRepository = AccountRepository(userDao)
+}

--- a/app/src/main/java/com/example/appmanagement/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/home/HomeFragment.kt
@@ -10,14 +10,12 @@ import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.example.appmanagement.R
-import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
-import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.viewmodel.TaskViewModel
 import com.example.appmanagement.databinding.FragmentHomeBinding
 import com.example.appmanagement.ui.menu.TaskAdapter
@@ -29,13 +27,15 @@ import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.util.Locale
 import kotlin.math.roundToInt
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class HomeFragment : Fragment() {
 
     private var _b: FragmentHomeBinding? = null
     private val b get() = _b!!
 
-    private lateinit var vm: TaskViewModel
+    private val vm: TaskViewModel by activityViewModels()
     private lateinit var searchAdapter: TaskAdapter
 
     override fun onCreateView(
@@ -44,7 +44,6 @@ class HomeFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _b = FragmentHomeBinding.inflate(inflater, container, false)
-        vm = ViewModelProvider(requireActivity())[TaskViewModel::class.java]
         return b.root
     }
 
@@ -60,12 +59,9 @@ class HomeFragment : Fragment() {
         vm.loadTasksForCurrentUser()
         vm.syncTasksForCurrentUser()
 
-        val db = AppDatabase.getInstance(requireContext())
-        val repo = AccountRepository(db.userDao())
-
         // User + avatar
         viewLifecycleOwner.lifecycleScope.launch {
-            val u = withContext(Dispatchers.IO) { repo.getCurrentUser() }
+            val u = withContext(Dispatchers.IO) { vm.getCurrentUserSafe() }
             if (u != null) {
                 b.tvHello.text = "${u.name}'s manager"
                 when (u.avatarUrl) {
@@ -116,15 +112,11 @@ class HomeFragment : Fragment() {
                 )
             },
             onDeleteClick = { task ->
-                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                    db.taskDao().delete(task)
-                }
+                vm.deleteTask(task)
             },
             onCheckClick = { task ->
                 // Cập nhật DB; UI sẽ tự đồng bộ lại qua observer ở trên
-                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                    db.taskDao().setCompleted(task.id, !task.isCompleted)
-                }
+                vm.toggleTask(task)
             }
         )
 

--- a/app/src/main/java/com/example/appmanagement/ui/login/SignInFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/login/SignInFragment.kt
@@ -13,7 +13,9 @@ import com.example.appmanagement.R
 import com.example.appmanagement.data.viewmodel.SignInViewModel
 import com.example.appmanagement.databinding.FragmentSignInBinding
 import com.example.appmanagement.util.AppGlobals
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SignInFragment : Fragment() {
 
     private var _binding: FragmentSignInBinding? = null

--- a/app/src/main/java/com/example/appmanagement/ui/login/SignUpFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/login/SignUpFragment.kt
@@ -12,7 +12,9 @@ import androidx.navigation.fragment.findNavController
 import com.example.appmanagement.R
 import com.example.appmanagement.data.viewmodel.SignInViewModel
 import com.example.appmanagement.databinding.FragmentSignUpBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class SignUpFragment : Fragment() {
 
     private var _binding: FragmentSignUpBinding? = null

--- a/app/src/main/java/com/example/appmanagement/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/main/MainActivity.kt
@@ -23,7 +23,9 @@ import com.example.appmanagement.R
 import com.example.appmanagement.databinding.ActivityMainBinding
 import com.example.appmanagement.util.ThemeManager
 import com.google.android.material.navigation.NavigationBarView
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding

--- a/app/src/main/java/com/example/appmanagement/ui/onboard/OnboardFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/onboard/OnboardFragment.kt
@@ -21,7 +21,9 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.common.api.ApiException
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class OnboardFragment : Fragment() {
 
     private var _binding: FragmentOnboardBinding? = null

--- a/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.entity.Task
+import com.example.appmanagement.data.entity.User
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
@@ -29,6 +30,7 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
     }
     private val accountRepository by lazy { AccountRepository(database.userDao()) }
 
+    private var currentUser: User? = null
     private val currentUserId = MutableLiveData<Long?>()
 
     private val _tasksAll = MediatorLiveData<List<Task>>()
@@ -76,6 +78,7 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun loadCurrentUser() = viewModelScope.launch {
         val user = withContext(Dispatchers.IO) { accountRepository.getCurrentUser() }
+        currentUser = user
         currentUserId.value = user?.id
     }
 
@@ -98,8 +101,8 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
         startTime: String,
         endTime: String
     ) = viewModelScope.launch(Dispatchers.IO) {
-        val uid = currentUserId.value ?: return@launch
-        taskRepository.add(uid, title, description, taskDate, startTime, endTime)
+        val user = currentUser ?: return@launch
+        taskRepository.add(user, title, description, taskDate, startTime, endTime)
     }
 
     /** Cập nhật Task */

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,4 +5,5 @@ plugins {
     id("androidx.navigation.safeargs.kotlin") version "2.8.1" apply false
     id("com.google.gms.google-services") version "4.4.3" apply false
     id("org.jetbrains.kotlin.kapt") version "2.0.21" apply false
+    id("com.google.dagger.hilt.android") version "2.52" apply false
 }


### PR DESCRIPTION
## Summary
- add Hilt configuration with application entry point, DI module, and Gradle plugins/dependencies
- require user context when creating tasks so remote sync uses the associated account
- update core viewmodels, fragments, and activity to leverage injected dependencies and repository calls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923feb66e50832581df13b103f930a2)