### PR TITLE
Ensure tasks are tied to logged-in users and refine Google sign-in

### DIFF
--- a/app/src/main/java/com/example/appmanagement/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/example/appmanagement/data/db/AppDatabase.kt
@@ -14,7 +14,7 @@ import com.example.appmanagement.data.entity.User
 
 @Database(
     entities = [User::class, Task::class],
-    version = 2,            // tăng version 1 -> 2 vì đã thêm cột mới
+    version = 3,            // tăng version khi thay đổi schema
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -39,6 +39,13 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // thêm cột user_remote_id để liên kết với uid Firebase
+                db.execSQL("ALTER TABLE tasks ADD COLUMN user_remote_id TEXT")
+            }
+        }
+
         fun getInstance(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -47,7 +54,7 @@ abstract class AppDatabase : RoomDatabase() {
                     "todo.db"            // tên file cơ sở dữ liệu
                 )
                     // dùng migration để giữ lại dữ liệu cũ khi nâng version
-                    .addMigrations(MIGRATION_1_2)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/example/appmanagement/data/entity/Task.kt
+++ b/app/src/main/java/com/example/appmanagement/data/entity/Task.kt
@@ -13,7 +13,10 @@ import androidx.room.*
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index(value = ["user_id"])]
+    indices = [
+        Index(value = ["user_id"]),
+        Index(value = ["user_remote_id"])
+    ]
 )
 data class Task(
 
@@ -22,6 +25,9 @@ data class Task(
 
     @ColumnInfo(name = "user_id")
     val userId: Long,                // id user sở hữu task
+
+    @ColumnInfo(name = "user_remote_id")
+    val userRemoteId: String? = null,// uid Firebase của user để sync Firestore
 
     @ColumnInfo(name = "order_index")
     val orderIndex: Int = 0,         // thứ tự hiển thị

--- a/app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt
+++ b/app/src/main/java/com/example/appmanagement/data/remote/TaskRemoteDataSource.kt
@@ -44,6 +44,7 @@ class TaskRemoteDataSource(
             Task(
                 id = 0,
                 userId = 0,
+                userRemoteId = data["userId"] as? String,
                 remoteId = doc.id,
                 title = data["title"] as? String ?: "",
                 description = data["description"] as? String ?: "",

--- a/app/src/main/java/com/example/appmanagement/data/viewmodel/SignInViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/data/viewmodel/SignInViewModel.kt
@@ -77,12 +77,12 @@ class SignInViewModel @Inject constructor(
     // loginWithGoogleUser – nhận FirebaseUser – gọi repo.loginWithGoogleAccount – trả User về callback
     fun loginWithGoogleUser(
         firebaseUser: FirebaseUser,
-        onSuccess: (User) -> Unit,
+        onSuccess: (User, Boolean) -> Unit,
         onError: (Throwable) -> Unit
     ) {
         viewModelScope.launch {
             try {
-                val user = withContext(Dispatchers.IO) {
+                val result = withContext(Dispatchers.IO) {
                     accountRepository.loginWithGoogleAccount(
                         uid = firebaseUser.uid,
                         email = firebaseUser.email,
@@ -90,7 +90,7 @@ class SignInViewModel @Inject constructor(
                         avatarUrl = firebaseUser.photoUrl?.toString()
                     )
                 }
-                onSuccess(user)
+                onSuccess(result.user, result.isNewUser)
             } catch (e: Throwable) {
                 onError(e)
             }

--- a/app/src/main/java/com/example/appmanagement/ui/onboard/OnboardFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/onboard/OnboardFragment.kt
@@ -112,10 +112,14 @@ class OnboardFragment : Fragment() {
 
                 viewModel.loginWithGoogleUser(
                     firebaseUser = firebaseUser,
-                    onSuccess = { user ->
+                    onSuccess = { user, isNewUser ->
                         toast("Xin chào ${user.name}!")
                         taskViewModel.syncTasksForCurrentUser()
-                        findNavController().navigate(R.id.homeFragment)
+                        if (isNewUser) {
+                            findNavController().navigate(R.id.createWorkFragment)
+                        } else {
+                            findNavController().navigate(R.id.homeFragment)
+                        }
                     },
                     onError = {
                         toast("Lỗi lưu tài khoản vào hệ thống!")


### PR DESCRIPTION
## Summary
- add userRemoteId to tasks, migrate the Room schema, and persist the remote user when syncing tasks
- route task creation through the repository for Firestore upserts and scope list queries by the signed-in user
- adjust Google sign-in/logout flows to send new accounts to profile creation and clear credentials so the account picker reappears

## Testing
- ./gradlew test *(fails: Hilt Gradle plugin dependency not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924249f4e1c8325a60cac237c3750b9)