### PR TITLE
Improve offline task handling and sync stability

### DIFF
--- a/app/src/main/java/com/example/appmanagement/data/dao/TaskDao.kt
+++ b/app/src/main/java/com/example/appmanagement/data/dao/TaskDao.kt
@@ -41,6 +41,14 @@ interface TaskDao {
     @Query("SELECT * FROM tasks WHERE user_id = :userId AND task_date = :date ORDER BY start_time ASC")
     fun getByDate(userId: Long, date: String): LiveData<List<Task>>
 
+    // Trả về toàn bộ task một lần (dùng cho đồng bộ nền)
+    @Query("SELECT * FROM tasks WHERE user_id = :userId")
+    suspend fun getAllOnce(userId: Long): List<Task>
+
+    // Các task chưa có remote_id để đồng bộ lên server khi có mạng
+    @Query("SELECT * FROM tasks WHERE user_id = :userId AND (remote_id IS NULL OR remote_id = '')")
+    suspend fun getUnsynced(userId: Long): List<Task>
+
     // ===== UPDATE =====   
     @Update
     suspend fun update(task: Task): Int


### PR DESCRIPTION
## Summary
- harden Firestore task data source and repository sync flow so offline operations do not crash
- push local changes before pulling remote updates to keep tasks synchronized when connectivity returns
- prevent duplicate task submissions from the add screen and surface a friendly offline message

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692513c230fc83258ee3cf581f76bf53)