### PR TITLE
Handle offline task creation and syncing

### DIFF
--- a/app/src/main/java/com/example/appmanagement/di/AppModule.kt
+++ b/app/src/main/java/com/example/appmanagement/di/AppModule.kt
@@ -7,6 +7,8 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import dagger.Module
 import dagger.Provides
@@ -41,11 +43,17 @@ object AppModule {
 
     @Provides
     @Singleton
+    fun provideNetworkChecker(@ApplicationContext context: Context): NetworkChecker =
+        NetworkChecker { NetworkUtils.isOnline(context) }
+
+    @Provides
+    @Singleton
     fun provideTaskRepository(
         taskDao: TaskDao,
         userDao: UserDao,
-        remoteDataSource: TaskRemoteDataSource
-    ): TaskRepository = TaskRepository(taskDao, userDao, remoteDataSource)
+        remoteDataSource: TaskRemoteDataSource,
+        networkChecker: NetworkChecker
+    ): TaskRepository = TaskRepository(taskDao, userDao, remoteDataSource, networkChecker)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/example/appmanagement/ui/menu/AddFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/AddFragment.kt
@@ -18,6 +18,8 @@ import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.TaskRepository
 import com.example.appmanagement.databinding.FragmentAddBinding
 import com.example.appmanagement.notifications.NotificationScheduler
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -138,7 +140,8 @@ class AddFragment : Fragment() {
                 val taskRepository = TaskRepository(
                     dao = db.taskDao(),
                     userDao = db.userDao(),
-                    remoteDataSource = TaskRemoteDataSource(FirebaseFirestore.getInstance())
+                    remoteDataSource = TaskRemoteDataSource(FirebaseFirestore.getInstance()),
+                    networkChecker = NetworkChecker { NetworkUtils.isOnline(appContext) }
                 )
 
                 val insertedId = withContext(Dispatchers.IO) {
@@ -167,7 +170,11 @@ class AddFragment : Fragment() {
                     Toast.makeText(requireContext(), "Thêm thất bại", Toast.LENGTH_SHORT).show()
                 }
             } catch (_: Exception) {
-                Toast.makeText(requireContext(), "Không thể thêm công việc khi mất mạng, sẽ thử đồng bộ lại", Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    requireContext(),
+                    "Không thể đồng bộ lên server, công việc đã được lưu offline",
+                    Toast.LENGTH_SHORT
+                ).show()
             } finally {
                 isSubmitting = false
                 if (isAdded) {

--- a/app/src/main/java/com/example/appmanagement/ui/menu/CalendarFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/CalendarFragment.kt
@@ -16,6 +16,8 @@ import com.example.appmanagement.data.entity.Task
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentCalendarBinding
 import kotlinx.coroutines.Dispatchers
@@ -68,7 +70,8 @@ class CalendarFragment : Fragment() {
         taskRepository = TaskRepository(
             database.taskDao(),
             database.userDao(),
-            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+            TaskRemoteDataSource(FirebaseFirestore.getInstance()),
+            NetworkChecker { NetworkUtils.isOnline(requireContext().applicationContext) }
         )
 
         // Khởi tạo adapter (đã là working list)

--- a/app/src/main/java/com/example/appmanagement/ui/menu/DoneFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/DoneFragment.kt
@@ -17,6 +17,8 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentDoneBinding
 import kotlinx.coroutines.Dispatchers
@@ -51,7 +53,8 @@ class DoneFragment : Fragment() {
         taskRepo = TaskRepository(
             db.taskDao(),
             db.userDao(),
-            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+            TaskRemoteDataSource(FirebaseFirestore.getInstance()),
+            NetworkChecker { NetworkUtils.isOnline(appContext) }
         )
 
         taskAdapter = TaskAdapter(

--- a/app/src/main/java/com/example/appmanagement/ui/menu/ListFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/ListFragment.kt
@@ -15,6 +15,8 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentListBinding
 import kotlinx.coroutines.Dispatchers
@@ -50,7 +52,8 @@ class ListFragment : Fragment() {
         taskRepo = TaskRepository(
             db.taskDao(),
             db.userDao(),
-            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+            TaskRemoteDataSource(FirebaseFirestore.getInstance()),
+            NetworkChecker { NetworkUtils.isOnline(appContext) }
         )
 
         taskAdapter = TaskAdapter(

--- a/app/src/main/java/com/example/appmanagement/ui/menu/TodayFragment.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/menu/TodayFragment.kt
@@ -17,6 +17,8 @@ import com.example.appmanagement.data.db.AppDatabase
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import com.google.firebase.firestore.FirebaseFirestore
 import com.example.appmanagement.databinding.FragmentTodayBinding
 import kotlinx.coroutines.Dispatchers
@@ -56,7 +58,8 @@ class TodayFragment : Fragment() {
         taskRepo = TaskRepository(
             db.taskDao(),
             db.userDao(),
-            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+            TaskRemoteDataSource(FirebaseFirestore.getInstance()),
+            NetworkChecker { NetworkUtils.isOnline(appContext) }
         )
 
         taskAdapter = TaskAdapter(

--- a/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
+++ b/app/src/main/java/com/example/appmanagement/ui/task/TaskViewModel.kt
@@ -14,6 +14,8 @@ import com.example.appmanagement.data.repo.AccountRepository
 import com.example.appmanagement.data.repo.TaskRepository
 import com.example.appmanagement.data.remote.TaskRemoteDataSource
 import com.google.firebase.firestore.FirebaseFirestore
+import com.example.appmanagement.util.NetworkChecker
+import com.example.appmanagement.util.NetworkUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -25,7 +27,8 @@ class TaskViewModel(application: Application) : AndroidViewModel(application) {
         TaskRepository(
             database.taskDao(),
             database.userDao(),
-            TaskRemoteDataSource(FirebaseFirestore.getInstance())
+            TaskRemoteDataSource(FirebaseFirestore.getInstance()),
+            NetworkChecker { NetworkUtils.isOnline(application) }
         )
     }
     private val accountRepository by lazy { AccountRepository(database.userDao()) }

--- a/app/src/main/java/com/example/appmanagement/util/NetworkUtils.kt
+++ b/app/src/main/java/com/example/appmanagement/util/NetworkUtils.kt
@@ -1,0 +1,22 @@
+package com.example.appmanagement.util
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+
+fun interface NetworkChecker {
+    fun isOnline(): Boolean
+}
+
+object NetworkUtils {
+    fun isOnline(context: Context): Boolean {
+        val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
+            ?: return false
+        val network = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(network) ?: return false
+        return caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+                caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
+                caps.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) ||
+                caps.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable network checker utility for connectivity-aware logic
- guard task remote sync operations so tasks can be created and updated offline and only push when online
- wire network checks into task repository consumers so offline additions are retained and synced when connectivity returns

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69252b2454dc8325980089aea731437f)